### PR TITLE
Add PHP 8 Docker environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+.dockerignore
+docker-compose.yml
+Dockerfile
+vendor/
+composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:8.2-cli
+
+# Install system dependencies and composer
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["php"]
+CMD ["-a"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# JPKGenerator
+
+This repository contains a PHP library. A Docker environment using PHP 8 is included to ease development and testing of future scripts.
+
+## Requirements
+
+- Docker
+- Docker Compose
+
+## Usage
+
+Build the container and start an interactive PHP shell:
+
+```bash
+docker compose run --rm app
+```
+
+To run a specific PHP script:
+
+```bash
+docker compose run --rm app /app/your_script.php
+```
+
+The working directory `/app` inside the container is mounted from the project root so changes on the host are immediately available in the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/app
+    working_dir: /app
+    tty: true
+    command: -a


### PR DESCRIPTION
## Summary
- add PHP 8.2 Dockerfile with Composer and basic dependencies
- provide docker-compose setup with shared working directory
- add ignore files and README instructions

## Testing
- `docker-compose build` *(fails: Error while fetching server API version: connection aborted; Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f4b30520832fa429a424b4443e81