### PR TITLE
Add XmlGenerator to build JPK XML from Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,20 @@ docker compose run --rm app /app/your_script.php
 ```
 
 The working directory `/app` inside the container is mounted from the project root so changes on the host are immediately available in the container.
+
+## XML Generation
+
+The library contains an `XmlGenerator` class capable of transforming a populated `Document` object into the final JPK XML string. Only fields with non-null values are included in the output and attributes are respected.
+
+```php
+<?php
+use DevLancer\JPKGenerator\{Document, XmlGenerator};
+
+$document = new Document();
+// populate $document with data …
+
+$xml = (new XmlGenerator())->generate($document);
+file_put_contents('jpk.xml', $xml);
+```
+
+The generator applies the correct namespace prefixes and recursively serializes nested `ParameterBag` structures.

--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace DevLancer\JPKGenerator;
+
+use DOMDocument;
+use DOMElement;
+use ReflectionClass;
+use DateTimeInterface;
+
+final class XmlGenerator
+{
+    private const DEFAULT_PREFIX = 'tns';
+    /**
+     * Mapping of element names to namespace prefixes
+     * @var array<string,string>
+     */
+    private array $prefixMap;
+
+    public function __construct(array $prefixMap = [])
+    {
+        // default mapping for elements that should use 'etd' prefix
+        $this->prefixMap = $prefixMap + [
+            'NIP' => 'etd',
+            'ImiePierwsze' => 'etd',
+            'Nazwisko' => 'etd',
+            'DataUrodzenia' => 'etd',
+        ];
+    }
+
+    public function generate(Document $document): string
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+
+        $rootBag = $document->getJpk();
+        $rootElement = $this->createElement($dom, $rootBag);
+        if ($rootElement !== null) {
+            $dom->appendChild($rootElement);
+        }
+
+        return $dom->saveXML();
+    }
+
+    private function createElement(DOMDocument $dom, ParameterBag $bag): ?DOMElement
+    {
+        $value = $bag->getValue();
+        if ($value === null) {
+            return null;
+        }
+
+        $tagName = $this->resolveTagName($bag->getTagName());
+        $element = $dom->createElement($tagName);
+
+        foreach ($bag->getAttributesList() as $attr) {
+            if ($bag->hasAttribute($attr)) {
+                $element->setAttribute($attr, (string) $bag->getAttribute($attr));
+            }
+        }
+
+        if (is_object($value)) {
+            $ref = new ReflectionClass($value);
+            foreach ($ref->getProperties() as $property) {
+                $property->setAccessible(true);
+                $childBag = $property->getValue($value);
+                if ($childBag instanceof ParameterBag) {
+                    $childElement = $this->createElement($dom, $childBag);
+                    if ($childElement !== null) {
+                        $element->appendChild($childElement);
+                    }
+                }
+            }
+        } else {
+            $element->nodeValue = $this->scalarValue($value);
+        }
+
+        return $element;
+    }
+
+    private function resolveTagName(string $name): string
+    {
+        $prefix = $this->prefixMap[$name] ?? self::DEFAULT_PREFIX;
+        return $prefix !== '' ? $prefix . ':' . $name : $name;
+    }
+
+    private function scalarValue(mixed $value): string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d\TH:i:s\Z');
+        }
+        return (string) $value;
+    }
+}


### PR DESCRIPTION
## Summary
- add XmlGenerator that recursively serializes ParameterBag data into XML
- document XML generation usage in README

## Testing
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68a81c724354832f9ed50b650dc4439b