### PR TITLE
Remove required parameter from ParameterBag

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -19,7 +19,6 @@ class Document
         $this->jpk = new ParameterBag(
             "JPK",
             JPK::class,
-            true,
             [
                 'xmlns:etd', 'xmlns:tns'
             ]

--- a/src/Model/Deklaracja.php
+++ b/src/Model/Deklaracja.php
@@ -20,18 +20,15 @@ final class Deklaracja
         $this->naglowek = new ParameterBag(
             "Naglowek",
             NaglowekDeklaracja::class,
-            false,
         );
 
         $this->pozycjeSzczegolowe = new ParameterBag(
             "PozycjeSzczegolowe",
             PozycjeSzczegolowe::class,
-            false,
         );
         $this->pouczenia = new ParameterBag(
             "Pouczenia",
             "int",
-            false,
         );
     }
 

--- a/src/Model/Ewidencja.php
+++ b/src/Model/Ewidencja.php
@@ -23,7 +23,6 @@ final class Ewidencja
         $this->sprzedazCtrl = new ParameterBag(
             "SprzedazCtrl",
             SprzedazCtrl::class,
-            false
         );
     }
 
@@ -32,7 +31,6 @@ final class Ewidencja
         $parameterBag = new ParameterBag(
             "SprzedazWiersz",
             SprzedazWiersz::class,
-            false
         );
 
         $parameterBag->setValue($sprzedazWiersz);

--- a/src/Model/JPK.php
+++ b/src/Model/JPK.php
@@ -22,18 +22,15 @@ final class JPK
         $this->naglowek = new ParameterBag(
             "Naglowek",
             Naglowek::class,
-            false
         );
         $this->podmiot1 = new ParameterBag(
             "Podmiot1",
             Podmiot1::class,
-            false,
             ['rola']
         );
         $this->deklaracja = new ParameterBag(
             "Deklaracja",
             Deklaracja::class,
-            false,
             [
                 'xmlns', 'xmlns:tns', 'xmlns:etd'
             ]
@@ -41,7 +38,6 @@ final class JPK
         $this->ewidencja = new ParameterBag(
             "Ewidencja",
             Ewidencja::class,
-            false
         );
     }
 

--- a/src/Model/Naglowek.php
+++ b/src/Model/Naglowek.php
@@ -27,50 +27,42 @@ final class Naglowek
         $this->kodFormularza = new ParameterBag(
             "KodFormularza",
             "string",
-            false,
             ["kodSystemowy", "wersjaSchemy"]
         );
 
         $this->wariantFormularza = new ParameterBag(
             "WariantFormularza",
             "int",
-            false,
         );
 
         $this->dataWytworzeniaJPK = new ParameterBag(
             "DataWytworzeniaJPK",
             DateTime::class,
-            false,
         );
 
         $this->nazwaSystemu = new ParameterBag(
             "NazwaSystemu",
             "string",
-            false,
         );
 
         $this->celZlozenia = new ParameterBag(
             "CelZlozenia",
             "int",
-            false,
             ["poz"]
         );
 
         $this->kodUrzedu = new ParameterBag(
             "KodUrzedu",
             "int",
-            false,
         );
         $this->rok = new ParameterBag(
             "Rok",
             "int",
-            false,
         );
 
         $this->miesiac = new ParameterBag(
             "Miesiac",
             "int",
-            false,
         );
     }
 

--- a/src/Model/NaglowekDeklaracja.php
+++ b/src/Model/NaglowekDeklaracja.php
@@ -19,7 +19,6 @@ final class NaglowekDeklaracja
         $this->kodFormularzaDekl = new ParameterBag(
             "KodFormularzaDekl",
             "string",
-            false,
             [
                 "kodPodatku",
                 "kodSystemowy",
@@ -31,7 +30,6 @@ final class NaglowekDeklaracja
         $this->wariantFormularzaDekl = new ParameterBag(
             "WariantFormularzaDekl",
             "int",
-            false,
         );
     }
 

--- a/src/Model/OsobaFizyczna.php
+++ b/src/Model/OsobaFizyczna.php
@@ -23,28 +23,23 @@ final class OsobaFizyczna
         $this->nip = new ParameterBag(
             "NIP",
             "string",
-            false,
         );
 
         $this->imiePierwsze = new ParameterBag(
             "ImiePierwsze",
             "string",
-            false,
         );
         $this->nazwisko = new ParameterBag(
             "Nazwisko",
             "string",
-            false,
         );
         $this->dataUrodzenia = new ParameterBag(
             "DataUrodzenia",
             \DateTime::class,
-            false,
         );
         $this->email = new ParameterBag(
             "Email",
             "string",
-            false
         );
     }
 

--- a/src/Model/Podmiot1.php
+++ b/src/Model/Podmiot1.php
@@ -19,7 +19,6 @@ final class Podmiot1
         $this->osobaFizyczna = new ParameterBag(
             "OsobaFizyczna",
             OsobaFizyczna::class,
-            false,
         );
     }
 

--- a/src/Model/SprzedazCtrl.php
+++ b/src/Model/SprzedazCtrl.php
@@ -20,13 +20,11 @@ final class SprzedazCtrl
         $this->liczbaWierszySprzedaz = new ParameterBag(
             "LiczbaWierszySprzedaz",
             "float",
-            false
         );
 
         $this->podatekNalezny = new ParameterBag(
             "PodatekNalezny",
             "float",
-            false
         );
     }
 

--- a/src/Model/SprzedazWiersz.php
+++ b/src/Model/SprzedazWiersz.php
@@ -30,67 +30,56 @@ final class SprzedazWiersz
         $this->lpSprzedazy = new ParameterBag(
             "LpSprzedazy",
             "int",
-            false
         );
 
         $this->kodKrajuNadaniaTIN = new ParameterBag(
             "KodKrajuNadaniaTIN",
             "string",
-            false
         );
 
         $this->nrKontrahenta = new ParameterBag(
             "NrKontrahenta",
             "string",
-            true
         );
 
         $this->nazwaKontrahenta = new ParameterBag(
             "NazwaKontrahenta",
             "string",
-            false,
         );
 
         $this->dowodSprzedazy = new ParameterBag(
             "DowodSprzedazy",
             "string",
-            false
         );
 
         $this->dataWystawienia = new ParameterBag(
             "DataWystawienia",
             DateTime::class,
-        false
         );
 
         $this->dataSprzedazy = new ParameterBag(
             "DataSprzedazy",
             DateTime::class,
-            true,
         );
 
         $this->k_11 = new ParameterBag(
             "K_11",
             "float",
-            true,
         );
 
         $this->k_12 = new ParameterBag(
             "K_12",
             "float",
-            true,
         );
 
         $this->k_19 = new ParameterBag(
             "K_19",
             "float",
-            true,
         );
 
         $this->k_20 = new ParameterBag(
             "K_20",
             "float",
-            true,
         );
     }
 

--- a/src/ParameterBag.php
+++ b/src/ParameterBag.php
@@ -22,14 +22,12 @@ class ParameterBag
     private mixed $value = null;
     private array $attributesList;
     private array $attributes = [];
-    private bool $required;
 
-    public function __construct(string $tagName, string $typeValue, bool $required = false, array $attributesList = [])
+    public function __construct(string $tagName, string $typeValue, array $attributesList = [])
     {
         $this->tagName = $tagName;
         $this->typeValue = $typeValue;
         $this->attributesList = $attributesList;
-        $this->required = $required;
     }
 
     /**
@@ -104,15 +102,5 @@ class ParameterBag
     public function getTagName(): string
     {
         return $this->tagName;
-    }
-
-    public function isRequired(): bool
-    {
-        return $this->required;
-    }
-
-    public function setRequired(bool $required): void
-    {
-        $this->required = $required;
     }
 }


### PR DESCRIPTION
## Summary
- drop `required` flag from `ParameterBag` and remove related accessors
- update all `ParameterBag` instantiations to use simplified constructor

## Testing
- `php -l src/ParameterBag.php`
- `php -l src/Document.php`
- `php -l src/Model/JPK.php`
- `php -l src/Model/SprzedazCtrl.php`
- `php -l src/Model/Ewidencja.php`
- `php -l src/Model/Deklaracja.php`
- `php -l src/Model/Podmiot1.php`
- `php -l src/Model/SprzedazWiersz.php`
- `php -l src/Model/OsobaFizyczna.php`
- `php -l src/Model/Naglowek.php`
- `php -l src/Model/NaglowekDeklaracja.php`
- `composer validate --strict`


------
https://chatgpt.com/codex/tasks/task_e_68a829249dcc832fba765c70598e742a