### PR TITLE
Remove XML declaration from generated XML

### DIFF
--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -38,7 +38,9 @@ final class XmlGenerator
             $dom->appendChild($rootElement);
         }
 
-        return $dom->saveXML();
+        return $dom->documentElement !== null
+            ? $dom->saveXML($dom->documentElement) ?: ''
+            : '';
     }
 
     private function createElement(DOMDocument $dom, ParameterBag $bag): ?DOMElement


### PR DESCRIPTION
## Summary
- prevent `XmlGenerator` from adding the XML declaration by saving only the document element

## Testing
- `php -l src/XmlGenerator.php`
- `composer validate`
- `php -r 'require "vendor/autoload.php"; $d=new DevLancer\JPKGenerator\Document(); $bag=new DevLancer\JPKGenerator\ParameterBag("Root","string"); $bag->setValue("val"); $d->setJpk($bag); echo (new DevLancer\JPKGenerator\XmlGenerator())->generate($d);'`

------
https://chatgpt.com/codex/tasks/task_e_68a82bf43cf8832f92d6dc41a889c555