### PR TITLE
Handle arrays of ParameterBag in XML generator

### DIFF
--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -61,11 +61,21 @@ final class XmlGenerator
             $ref = new ReflectionClass($value);
             foreach ($ref->getProperties() as $property) {
                 $property->setAccessible(true);
-                $childBag = $property->getValue($value);
-                if ($childBag instanceof ParameterBag) {
-                    $childElement = $this->createElement($dom, $childBag);
+                $childValue = $property->getValue($value);
+
+                if ($childValue instanceof ParameterBag) {
+                    $childElement = $this->createElement($dom, $childValue);
                     if ($childElement !== null) {
                         $element->appendChild($childElement);
+                    }
+                } elseif (is_array($childValue)) {
+                    foreach ($childValue as $childBag) {
+                        if ($childBag instanceof ParameterBag) {
+                            $childElement = $this->createElement($dom, $childBag);
+                            if ($childElement !== null) {
+                                $element->appendChild($childElement);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- allow `XmlGenerator` to iterate over arrays of `ParameterBag` so lists like `Ewidencja::getAllSprzedazWiersz()` are serialized

## Testing
- `composer install`
- `php -l src/XmlGenerator.php`
- `php /tmp/test.php`

------
https://chatgpt.com/codex/tasks/task_e_68a82b286818832f9854ae45cf71b512