### PR TITLE
Respect ParameterBag prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ file_put_contents('jpk.xml', $xml);
 ```
 
 The generator applies the correct namespace prefixes and recursively serializes nested `ParameterBag` structures.
+When a `ParameterBag` specifies a custom prefix, it takes precedence over the generator's default mapping.

--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -50,7 +50,7 @@ final class XmlGenerator
             return null;
         }
 
-        $tagName = $this->resolveTagName($bag->getTagName());
+        $tagName = $this->resolveTagName($bag->getTagName(), $bag->getPrefix());
         $element = $dom->createElement($tagName);
 
         foreach ($bag->getAttributesList() as $attr) {
@@ -88,9 +88,9 @@ final class XmlGenerator
         return $element;
     }
 
-    private function resolveTagName(string $name): string
+    private function resolveTagName(string $name, ?string $prefix = null): string
     {
-        $prefix = $this->prefixMap[$name] ?? self::DEFAULT_PREFIX;
+        $prefix = $prefix ?? ($this->prefixMap[$name] ?? self::DEFAULT_PREFIX);
         return $prefix !== '' ? $prefix . ':' . $name : $name;
     }
 


### PR DESCRIPTION
## Summary
- honor per-element prefixes stored in `ParameterBag`
- document custom prefix precedence

## Testing
- `php -l src/XmlGenerator.php`
- `composer validate --no-check-all`
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e8168d4832f91b689979154b2b3