### PR TITLE
Handle DateTime values in XML output

### DIFF
--- a/src/XmlGenerator.php
+++ b/src/XmlGenerator.php
@@ -45,7 +45,9 @@ final class XmlGenerator
             }
         }
 
-        if (is_object($value)) {
+        if ($value instanceof DateTimeInterface || !is_object($value)) {
+            $element->nodeValue = $this->scalarValue($bag);
+        } else {
             $ref = new ReflectionClass($value);
             foreach ($ref->getProperties() as $property) {
                 $property->setAccessible(true);
@@ -67,8 +69,6 @@ final class XmlGenerator
                     }
                 }
             }
-        } else {
-            $element->nodeValue = $this->scalarValue($bag);
         }
 
         return $element;


### PR DESCRIPTION
## Summary
- Ensure `XmlGenerator` renders `DateTimeInterface` values as scalars rather than reflecting them
- Fix empty XML tags by outputting proper date strings for fields like `DataWytworzeniaJPK` and `DataSprzedazy`

## Testing
- `php -l src/XmlGenerator.php`
- `php test_dates.php`

------
https://chatgpt.com/codex/tasks/task_e_68a86057b178832f82c841914b7b0678